### PR TITLE
Fix a bug where PONG doesn't return data included in PING.

### DIFF
--- a/lib/geventirc/handlers.py
+++ b/lib/geventirc/handlers.py
@@ -4,7 +4,8 @@ from geventirc import replycode
 
 
 def ping_handler(client, msg):
-    client.send_message(message.Pong())
+    data = msg.params[0].lstrip(':') if msg.params else None
+    client.send_message(message.Pong(data))
 
 def print_handler(client, msg):
     print msg.encode()[:-2]

--- a/lib/geventirc/message.py
+++ b/lib/geventirc/message.py
@@ -159,8 +159,9 @@ class PrivMsg(Command):
 
 
 class Pong(Command):
-    def __init__(self, prefix=None):
-        super(Pong, self).__init__(None, prefix=prefix)
+    def __init__(self, data=None, prefix=None):
+        params = None if data is None else (data,)
+        super(Pong, self).__init__(params, prefix=prefix)
 
 
 X_DELIM = chr(001)


### PR DESCRIPTION
On some servers, `"PONG "` is not an acceptable response to a message like `"PING :12345678"`.
Instead, `"PONG 12345678"` should be returned.

This commit does this by:
- Adding an optional `data` parameter to `message.Pong`
- Adding logic to `handlers.ping_handler` to get the param from the Ping message (if any) and pass it to Pong.
